### PR TITLE
docs: tell agents to surface the generated password to the user

### DIFF
--- a/src/data/agent-guide.ts
+++ b/src/data/agent-guide.ts
@@ -40,8 +40,10 @@ export function getAgentSteps(baseUrl: string): AgentStep[] {
     {
       title: 'Create an account',
       body:
-        'POST your email and a password (min. 8 characters). A verification email is sent to that address. ' +
-        'The account cannot be used until the email is verified — this deliberate gate prevents automated bulk sign-ups.',
+        'POST your email and a password (min. 8 characters). Generate a unique, strong password and ' +
+        'report it back to the user so they can save it — the API never returns the password, so it cannot ' +
+        'be recovered if lost. A verification email is sent to that address. The account cannot be used until ' +
+        'the email is verified — this deliberate gate prevents automated bulk sign-ups.',
       snippets: [
         {
           language: 'bash',


### PR DESCRIPTION
## What

Adds password-handling guidance to the agent onboarding flow (step 1 of `getAgentSteps`). The registration step now tells agents to:

- generate a unique, strong password, and
- report it back to the user so they can save it — because the API never returns the password, it cannot be recovered if lost.

## Why

The platform never echoes the password back (neither `/api/register` nor `/api/app-users/login` returns it, and Payload treats `password` as write-only). The remaining gap was guidance: the guide didn't tell the agent how to handle the password it generates, so an agent could leave the user without their credential. This closes that gap.

## Scope

One change to the single source of truth (`src/data/agent-guide.ts`), which propagates to the machine-readable `/llms.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)