### PR TITLE
Link to /llms.txt + clarify recipient verification

### DIFF
--- a/src/app/(frontend)/(no-auth)/(home-nav)/page.tsx
+++ b/src/app/(frontend)/(no-auth)/(home-nav)/page.tsx
@@ -5,7 +5,6 @@ import '../../styles.css'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import Code from '@/components/code'
 import { htmlForm, reactForm, goForm } from '@/data/form-code'
-import { getAgentSteps } from '@/data/agent-guide'
 import Image from 'next/image'
 import Navbar from '@/components/navbar'
 
@@ -89,43 +88,19 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <AgentSection />
+      <section className="flex flex-col items-center pb-24 md:pb-48 px-6">
+        <div className="w-full max-w-[800px] border rounded-lg p-6 bg-background flex flex-col gap-3">
+          <h2 className="text-xl font-semibold">Building with an AI agent?</h2>
+          <p className="text-gray-600 text-sm">
+            Agents can run the whole platform over the HTTP API — create an account, build forms, and
+            reuse the generated form ID. The full step-by-step guide lives at{' '}
+            <a href="/llms.txt" className="underline underline-offset-4">
+              /llms.txt
+            </a>
+            .
+          </p>
+        </div>
+      </section>
     </div>
-  )
-}
-
-async function AgentSection() {
-  const steps = getAgentSteps(baseUrl)
-
-  return (
-    <section className="flex flex-col items-center pb-24 md:pb-48 px-6">
-      <div className="w-full max-w-[800px] flex flex-col gap-3 mb-8">
-        <h2 className="text-2xl font-semibold">For AI agents</h2>
-        <p className="text-gray-600 text-base">
-          Agents can use the entire platform over the HTTP API — create an account, build forms, and
-          reuse the generated form ID without leaving the terminal. A machine-readable version of
-          this guide lives at{' '}
-          <a href="/llms.txt" className="underline underline-offset-4">
-            /llms.txt
-          </a>
-          . Email verification is required to create an account, which keeps automated sign-ups from
-          abusing the service.
-        </p>
-      </div>
-
-      <ol className="w-full max-w-[800px] flex flex-col gap-8">
-        {steps.map((step, i) => (
-          <li key={i} className="flex flex-col gap-3">
-            <h3 className="font-semibold">
-              {i + 1}. {step.title}
-            </h3>
-            <p className="text-gray-600 text-sm">{step.body}</p>
-            {step.snippets?.map((snippet, j) => (
-              <Code key={j} code={snippet.code} language={snippet.language} />
-            ))}
-          </li>
-        ))}
-      </ol>
-    </section>
   )
 }

--- a/src/app/(frontend)/(no-auth)/layout.tsx
+++ b/src/app/(frontend)/(no-auth)/layout.tsx
@@ -13,6 +13,9 @@ export default async function Layout({ children }: { children: React.ReactNode }
           <Link className="text-sm text-center text-gray-500 hover:underline" href="/privacy">
             Privacy Policy
           </Link>
+          <a className="text-sm text-center text-gray-500 hover:underline" href="/llms.txt">
+            For AI agents
+          </a>
         </div>
 
         <p className="text-sm text-gray-500 block text-center">

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -6,6 +6,12 @@ import { Toaster } from 'sonner'
 export const metadata = {
   // description: 'A blank template using Payload in a Next.js app.',
   title: 'Simple Contact Form',
+  // Discoverability hint for agents/crawlers: the machine-readable usage guide.
+  alternates: {
+    types: {
+      'text/plain': '/llms.txt',
+    },
+  },
 }
 
 export default async function RootLayout(props: { children: React.ReactNode }) {

--- a/src/data/agent-guide.ts
+++ b/src/data/agent-guide.ts
@@ -90,8 +90,10 @@ export function getAgentSteps(baseUrl: string): AgentStep[] {
     {
       title: 'Add a recipient',
       body:
-        'Recipients are the inboxes that form submissions are forwarded to. A confirmation email (double opt-in) is sent to ' +
-        'the address; if it matches your own account email it is confirmed automatically.',
+        'Recipients are the inboxes that form submissions are forwarded to. Your account email is already verified from ' +
+        'sign-up, so adding it as a recipient confirms it automatically — it does not need to be verified again. Every ' +
+        'other email address must be verified individually: a double opt-in confirmation email is sent to it, and the ' +
+        'owner must click the link to confirm before it is active.',
       snippets: [
         {
           language: 'bash',


### PR DESCRIPTION
Two related agent-accessibility tweaks, kept separate from the password-guidance PR (#6).

## 1. Link to `/llms.txt` instead of inlining the guide on the home page
- The home page no longer renders the full step-by-step agent guide inline — that duplicated what `/llms.txt` already serves.
- `/llms.txt` is the rendered, canonical entry point agents look for, so the page now shows a short "Building with an AI agent?" callout that links to it.
- Added a **"For AI agents"** link in the site footer (every public page) and a discoverability hint in root metadata: `<link rel="alternate" type="text/plain" href="/llms.txt">`.
- The guide keeps a single source of truth (`src/data/agent-guide.ts` → `/llms.txt`); only the redundant HTML rendering was removed.

## 2. Clarify recipient verification rules
- Step 5 of the guide now states explicitly (matching `Recipients.ts`): the account email is already verified at sign-up, so adding it as a recipient is auto-confirmed and needs no re-verification, while every other recipient email must be verified individually via its own double opt-in confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CvB9Wkbd4zvNedhBJcLHZq)_