### PR TITLE
feat: add Open Graph + Twitter Card metadata with generated preview image

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,16 +1,42 @@
 import React from 'react'
+import type { Metadata } from 'next'
 import './styles.css'
 import '@/styles/globals.css'
 import { Toaster } from 'sonner'
 
-export const metadata = {
-  // description: 'A blank template using Payload in a Next.js app.',
-  title: 'Simple Contact Form',
-  // Discoverability hint for agents/crawlers: the machine-readable usage guide.
+const siteUrl = process.env.NEXT_PUBLIC_HOST_URL || 'https://simplecontactform.org'
+const description =
+  'Spam protected form submissions directly to your email inbox. No backend setup required.'
+
+export const metadata: Metadata = {
+  // Used to resolve the relative Open Graph / Twitter image URLs below to absolute ones.
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: 'Simple Contact Form',
+    template: '%s · Simple Contact Form',
+  },
+  description,
   alternates: {
+    canonical: '/',
+    // Discoverability hint for agents/crawlers: the machine-readable usage guide.
     types: {
       'text/plain': '/llms.txt',
     },
+  },
+  openGraph: {
+    type: 'website',
+    siteName: 'Simple Contact Form',
+    title: 'Simple Contact Form',
+    description,
+    url: siteUrl,
+    locale: 'en_US',
+    // The preview image is generated dynamically — see opengraph-image.tsx.
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Simple Contact Form',
+    description,
+    // The preview image is generated dynamically — see twitter-image.tsx.
   },
 }
 

--- a/src/app/(frontend)/opengraph-image.tsx
+++ b/src/app/(frontend)/opengraph-image.tsx
@@ -1,0 +1,37 @@
+import { ImageResponse } from 'next/og'
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+// Route segment config + metadata for the generated image.
+export const alt = 'Simple Contact Form'
+export const size = { width: 1200, height: 630 }
+export const contentType = 'image/png'
+
+export default async function OpengraphImage() {
+  // Read the logo from disk and inline it as a data URL so it renders inside ImageResponse.
+  const logo = await readFile(join(process.cwd(), 'public/images/scf_logo.png'))
+  const logoSrc = `data:image/png;base64,${logo.toString('base64')}`
+
+  // The logo is 408x208 (≈1.96:1). Render it at half the canvas width so there is
+  // plenty of whitespace around it on the 1200x630 preview.
+  const logoWidth = 600
+  const logoHeight = Math.round(logoWidth * (208 / 408))
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          display: 'flex',
+          width: '100%',
+          height: '100%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#ffffff',
+        }}
+      >
+        <img src={logoSrc} width={logoWidth} height={logoHeight} alt={alt} />
+      </div>
+    ),
+    { ...size },
+  )
+}

--- a/src/app/(frontend)/twitter-image.tsx
+++ b/src/app/(frontend)/twitter-image.tsx
@@ -1,0 +1,3 @@
+// Reuse the same generated preview image (white background, whitespace-padded
+// logo) for Twitter/X cards as for Open Graph.
+export { default, alt, size, contentType } from './opengraph-image'


### PR DESCRIPTION
Add proper sharing metadata to the frontend so links render rich previews:
- site title template, description, canonical URL and metadataBase in the
  root frontend layout, plus openGraph and twitter card config
- dynamically generate the preview image with next/og, centering the existing
  logo on a white canvas with whitespace around it (opengraph-image.tsx),
  reused for the Twitter card (twitter-image.tsx)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PsjZEnQG87QiNorxDT3UGN